### PR TITLE
Update setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,9 @@
 # -*- coding: utf-8 -*-
 from setuptools import setup, find_packages
-from pip.req import parse_requirements
+try: # for pip >= 10
+    from pip._internal.req import parse_requirements
+except ImportError: # for pip <= 9.0.3
+    from pip.req import parse_requirements
 import re, ast
 
 # get version from __version__ variable in ni_dark_theme/__init__.py


### PR DESCRIPTION
Fix according to https://stackoverflow.com/questions/25192794/no-module-named-pip-req
Compatible with newest pip versions